### PR TITLE
Fix Vacantes page with application form

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -427,6 +427,37 @@ footer.slide-up {
   padding: 1rem;
 }
 
+/* Formulario de vacantes */
+.vacantes-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+.vacantes-form input,
+.vacantes-form textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.vacantes-form button {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  background-color: #006341;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.vacantes-form button:hover {
+  background-color: #004d33;
+}
+
 
 .historia-contenido {
   display: flex;

--- a/enviar_vacantes.php
+++ b/enviar_vacantes.php
@@ -1,0 +1,24 @@
+<?php
+if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    $nombre = strip_tags(trim($_POST["nombre"]));
+    $correo = filter_var(trim($_POST["correo"]), FILTER_SANITIZE_EMAIL);
+    $telefono = strip_tags(trim($_POST["telefono"]));
+    $puesto = strip_tags(trim($_POST["puesto"]));
+    $mensaje = trim($_POST["mensaje"]);
+
+    $destinatario = "reclutamiento@axtraltec.com";
+    $asunto = "Solicitud de empleo";
+    $contenido = "Nombre: $nombre\nCorreo: $correo\nTeléfono: $telefono\nPuesto de interés: $puesto\nMensaje:\n$mensaje";
+    $encabezados = "From: $nombre <$correo>";
+
+    if (mail($destinatario, $asunto, $contenido, $encabezados)) {
+        echo "<script>alert('Informaci\xC3\xB3n enviada correctamente');window.history.back();</script>";
+    } else {
+        echo "<script>alert('Error al enviar la informaci\xC3\xB3n');window.history.back();</script>";
+    }
+} else {
+    http_response_code(403);
+    echo "Hubo un problema al procesar el formulario.";
+}
+?>
+

--- a/vacantes.php
+++ b/vacantes.php
@@ -41,7 +41,26 @@
 </section>
     
     <section class="seccion">
-      <p>Estamos buscando talento. Envía tu CV a: reclutamiento@axtraltec.com</p>
+      <p>Estamos buscando talento. Completa el siguiente formulario y nos pondremos en contacto contigo:</p>
+
+      <form class="vacantes-form" action="enviar_vacantes.php" method="POST">
+        <label for="nombre">Nombre:</label>
+        <input type="text" id="nombre" name="nombre" required>
+
+        <label for="correo">Correo:</label>
+        <input type="email" id="correo" name="correo" required>
+
+        <label for="telefono">Teléfono:</label>
+        <input type="tel" id="telefono" name="telefono" required>
+
+        <label for="puesto">Puesto de interés:</label>
+        <input type="text" id="puesto" name="puesto" required>
+
+        <label for="mensaje">Mensaje:</label>
+        <textarea id="mensaje" name="mensaje" rows="4" required></textarea>
+
+        <button type="submit">Enviar</button>
+      </form>
     </section>
     
   </main>


### PR DESCRIPTION
## Summary
- add job application form to `vacantes.php`
- create `enviar_vacantes.php` to send form data to recruitment team
- style form via `.vacantes-form` rules in CSS

## Testing
- `php -l vacantes.php`
- `php -l enviar_vacantes.php`
- `php -l contacto.php`
- `php -l enviar.php`
- `php -l index.php`
- `php -l historia.php`
- `php -l mision.php`
- `php -l principios.php`
- `php -l conexion.php`

------
https://chatgpt.com/codex/tasks/task_e_688ac79ed8e0832394bd025f9e0d517f