### PR TITLE
Add simple login with employee-only vacancies page

### DIFF
--- a/contacto.php
+++ b/contacto.php
@@ -1,3 +1,4 @@
+<?php session_start(); ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -30,6 +31,12 @@
             </ul>
         </li>
         <li><a href="contacto.php">Contacto</a></li>
+<?php if(isset($_SESSION["usuario_id"])): ?>
+<li><a href="vacantes_internas.php">Vacantes internas</a></li>
+<li><a href="logout.php">Cerrar sesión</a></li>
+<?php else: ?>
+<li><a href="login.php">Personal</a></li>
+<?php endif; ?>
       </ul>
     </nav>
   </header>

--- a/css/style.css
+++ b/css/style.css
@@ -884,3 +884,8 @@ footer.slide-up {
   max-width: 800px;
   padding: 1rem;
 }
+.login-container{max-width:400px;margin:2rem auto;padding:1rem;border:1px solid #ccc;border-radius:4px;}
+.login-container label{display:block;margin-top:0.5rem;}
+.login-container input{width:100%;padding:0.5rem;margin-top:0.25rem;}
+.error{color:red;}
+

--- a/historia.php
+++ b/historia.php
@@ -1,3 +1,4 @@
+<?php session_start(); ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -30,6 +31,12 @@
             </ul>
         </li>
         <li><a href="contacto.php">Contacto</a></li>
+<?php if(isset($_SESSION["usuario_id"])): ?>
+<li><a href="vacantes_internas.php">Vacantes internas</a></li>
+<li><a href="logout.php">Cerrar sesión</a></li>
+<?php else: ?>
+<li><a href="login.php">Personal</a></li>
+<?php endif; ?>
       </ul>
     </nav>
   </header>

--- a/index.php
+++ b/index.php
@@ -1,3 +1,4 @@
+<?php session_start(); ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -29,6 +30,12 @@
         <li><a href="principios.php">Principios</a></li>
         </ul></li>
         <li><a href="contacto.php">Contacto</a></li>
+<?php if(isset($_SESSION["usuario_id"])): ?>
+<li><a href="vacantes_internas.php">Vacantes internas</a></li>
+<li><a href="logout.php">Cerrar sesión</a></li>
+<?php else: ?>
+<li><a href="login.php">Personal</a></li>
+<?php endif; ?>
       </ul>
     </nav>
   </header>

--- a/login.php
+++ b/login.php
@@ -1,0 +1,47 @@
+<?php
+session_start();
+require_once 'conexion.php';
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $usuario = trim($_POST['usuario']);
+    $contrasena = $_POST['contrasena'];
+
+    $stmt = $conn->prepare('SELECT id, password, rol FROM usuarios WHERE usuario = ?');
+    $stmt->bind_param('s', $usuario);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($row = $result->fetch_assoc()) {
+        if (password_verify($contrasena, $row['password'])) {
+            $_SESSION['usuario_id'] = $row['id'];
+            $_SESSION['rol'] = $row['rol'];
+            header('Location: vacantes_internas.php');
+            exit();
+        }
+    }
+    $error = 'Credenciales incorrectas';
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Iniciar sesi&oacute;n</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<div class="login-container">
+    <h2>Iniciar sesi&oacute;n</h2>
+    <?php if ($error): ?>
+        <p class="error"><?php echo $error; ?></p>
+    <?php endif; ?>
+    <form method="POST" action="login.php">
+        <label for="usuario">Usuario:</label>
+        <input type="text" id="usuario" name="usuario" required>
+        <label for="contrasena">Contrase&ntilde;a:</label>
+        <input type="password" id="contrasena" name="contrasena" required>
+        <button type="submit">Ingresar</button>
+    </form>
+</div>
+</body>
+</html>

--- a/logout.php
+++ b/logout.php
@@ -1,0 +1,7 @@
+<?php
+session_start();
+session_unset();
+session_destroy();
+header('Location: index.php');
+exit();
+?>

--- a/mision.php
+++ b/mision.php
@@ -1,3 +1,4 @@
+<?php session_start(); ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -30,6 +31,12 @@
             </ul>
         </li>
         <li><a href="contacto.php">Contacto</a></li>
+<?php if(isset($_SESSION["usuario_id"])): ?>
+<li><a href="vacantes_internas.php">Vacantes internas</a></li>
+<li><a href="logout.php">Cerrar sesión</a></li>
+<?php else: ?>
+<li><a href="login.php">Personal</a></li>
+<?php endif; ?>
       </ul>
     </nav>
   </header>

--- a/principios.php
+++ b/principios.php
@@ -1,3 +1,4 @@
+<?php session_start(); ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -30,6 +31,12 @@
             </ul>
         </li>
         <li><a href="contacto.php">Contacto</a></li>
+<?php if(isset($_SESSION["usuario_id"])): ?>
+<li><a href="vacantes_internas.php">Vacantes internas</a></li>
+<li><a href="logout.php">Cerrar sesión</a></li>
+<?php else: ?>
+<li><a href="login.php">Personal</a></li>
+<?php endif; ?>
       </ul>
     </nav>
   </header>

--- a/vacantes.php
+++ b/vacantes.php
@@ -1,3 +1,4 @@
+<?php session_start(); ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
@@ -29,7 +30,13 @@
         <li><a href="principios.php">Principios</a></li>
             </ul>
         </li>
-        <li><a href="contacto.php">Contacto</a></li>
+<li><a href="contacto.php">Contacto</a></li>
+<?php if(isset($_SESSION["usuario_id"])): ?>
+<li><a href="vacantes_internas.php">Vacantes internas</a></li>
+<li><a href="logout.php">Cerrar sesión</a></li>
+<?php else: ?>
+<li><a href="login.php">Personal</a></li>
+<?php endif; ?>
       </ul>
     </nav>
   </header>

--- a/vacantes_internas.php
+++ b/vacantes_internas.php
@@ -1,0 +1,32 @@
+<?php
+session_start();
+if (!isset($_SESSION['usuario_id'])) {
+    header('Location: login.php');
+    exit();
+}
+require_once 'conexion.php';
+
+$stmt = $conn->prepare('SELECT puesto, descripcion FROM vacantes');
+$stmt->execute();
+$result = $stmt->get_result();
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Vacantes internas</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+<div class="vacantes-internas">
+    <h2>Vacantes internas</h2>
+    <p>Bienvenido, <?php echo htmlspecialchars($_SESSION['rol']); ?>.</p>
+    <a href="logout.php">Cerrar sesi&oacute;n</a>
+    <ul>
+    <?php while ($vac = $result->fetch_assoc()): ?>
+        <li><strong><?php echo htmlspecialchars($vac['puesto']); ?></strong>: <?php echo htmlspecialchars($vac['descripcion']); ?></li>
+    <?php endwhile; ?>
+    </ul>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add login form and session logic
- add private vacancies page and logout handler
- update navigation to show Personal links and require login
- tweak CSS with styles for login page

## Testing
- `php -l login.php`
- `php -l vacantes_internas.php`
- `php -l logout.php`
- `php -l index.php`
- `php -l contacto.php`
- `php -l vacantes.php`
- `php -l historia.php`
- `php -l mision.php`
- `php -l principios.php`


------
https://chatgpt.com/codex/tasks/task_e_688acb2cd9588323bba9723ae2d6f097