### PR TITLE
Add database setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Sitio PEMEX
+
+Este proyecto es un sitio web simple desarrollado en PHP. Incluye un formulario de inicio de sesi\xC3\xB3n que valida las credenciales contra una base de datos MySQL.
+
+## Configuraci\xC3\xB3n de la base de datos
+
+1. Crea una base de datos MySQL y un usuario con permisos. Las credenciales por defecto se encuentran en `conexion.php`.
+2. Ejecuta el script `sql/setup.sql` para crear las tablas necesarias (`usuarios` y `vacantes`) e insertar un usuario de ejemplo.
+
+```bash
+mysql -u <usuario> -p < sql/setup.sql
+```
+
+El usuario de ejemplo se llama `admin` y la contrase\xC3\xB1a es `admin123`.
+
+## Uso
+
+- Accede a `login.php` e introduce las credenciales.
+- Al iniciar sesi\xC3\xB3n exitosamente podr\xC3\xA1s consultar `vacantes_internas.php`.
+

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -1,0 +1,21 @@
+CREATE DATABASE IF NOT EXISTS axelanto_pemex_bd DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+USE axelanto_pemex_bd;
+
+CREATE TABLE IF NOT EXISTS usuarios (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    usuario VARCHAR(50) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    rol VARCHAR(50) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS vacantes (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    puesto VARCHAR(100) NOT NULL,
+    descripcion TEXT NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO usuarios (usuario, password, rol) VALUES
+('admin', '$2y$12$rYFelBfwLsXPv0QWvEVpVu1ZXydP/3idi7FtK4Atn7WH/ZIi5rryS', 'administrador');
+
+INSERT INTO vacantes (puesto, descripcion) VALUES
+('Ejemplo de puesto', 'Ejemplo de descripcion');


### PR DESCRIPTION
## Summary
- add SQL script to create `usuarios` and `vacantes`
- provide README with instructions for database and login

## Testing
- `php -l login.php`
- `php -l sql/setup.sql`

------
https://chatgpt.com/codex/tasks/task_e_688ace818fe08323aa8188d8233be757