### PR TITLE
Enable CV uploads for vacancies

### DIFF
--- a/enviar_vacantes.php
+++ b/enviar_vacantes.php
@@ -6,9 +6,25 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $puesto = strip_tags(trim($_POST["puesto"]));
     $mensaje = trim($_POST["mensaje"]);
 
+    $cv_path = '';
+    if (isset($_FILES['cv']) && $_FILES['cv']['error'] === UPLOAD_ERR_OK) {
+        $dir = __DIR__ . '/cvs/';
+        if (!is_dir($dir)) {
+            mkdir($dir, 0777, true);
+        }
+        $file_name = uniqid() . '_' . basename($_FILES['cv']['name']);
+        $file_path = $dir . $file_name;
+        if (move_uploaded_file($_FILES['cv']['tmp_name'], $file_path)) {
+            $cv_path = $file_path;
+        }
+    }
+
     $destinatario = "reclutamiento@axtraltec.com";
     $asunto = "Solicitud de empleo";
     $contenido = "Nombre: $nombre\nCorreo: $correo\nTeléfono: $telefono\nPuesto de interés: $puesto\nMensaje:\n$mensaje";
+    if ($cv_path) {
+        $contenido .= "\nCV guardado en: $cv_path";
+    }
     $encabezados = "From: $nombre <$correo>";
 
     if (mail($destinatario, $asunto, $contenido, $encabezados)) {

--- a/vacantes.php
+++ b/vacantes.php
@@ -68,7 +68,7 @@ $puesto_solicitud = isset($_GET['puesto']) ? $_GET['puesto'] : '';
 
     <section id="form-aplicar" class="seccion">
       <h2>Enviar solicitud</h2>
-      <form class="vacantes-form" action="enviar_vacantes.php" method="POST">
+      <form class="vacantes-form" action="enviar_vacantes.php" method="POST" enctype="multipart/form-data">
         <label for="nombre">Nombre:</label>
         <input type="text" id="nombre" name="nombre" required>
 
@@ -83,6 +83,9 @@ $puesto_solicitud = isset($_GET['puesto']) ? $_GET['puesto'] : '';
 
         <label for="mensaje">Mensaje:</label>
         <textarea id="mensaje" name="mensaje" rows="4" required></textarea>
+
+        <label for="cv">Curr&iacute;culum (PDF/DOC):</label>
+        <input type="file" id="cv" name="cv" accept=".pdf,.doc,.docx" required>
 
         <button type="submit">Enviar</button>
       </form>


### PR DESCRIPTION
## Summary
- add persistent directory for CV uploads
- allow file upload in the vacancy application form
- store uploaded CVs server-side and mention path in the email

## Testing
- `php -l vacantes.php`
- `php -l enviar_vacantes.php`
- `php -l vacantes_internas.php`


------
https://chatgpt.com/codex/tasks/task_e_688aea81288c8323a2e95ac6a614cbe0