### PR TITLE
Add admin edit/delete for vacancies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ El usuario de ejemplo se llama `admin` y la contrase\xC3\xB1a es `admin123`.
 
 - Accede a `login.php` e introduce las credenciales.
 - Tras iniciar sesi\xC3\xB3n se muestra el `dashboard.php`, donde podr\xC3\xA1s administrar las vacantes.
+- Desde el panel de administraci\xC3\xB3n puedes crear, editar o eliminar vacantes existentes.
 

--- a/dashboard.php
+++ b/dashboard.php
@@ -6,15 +6,37 @@ if (!isset($_SESSION['usuario_id'])) {
 }
 require_once 'conexion.php';
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['puesto'], $_POST['descripcion'])) {
-    $puesto = trim($_POST['puesto']);
-    $descripcion = trim($_POST['descripcion']);
-    $stmt = $conn->prepare("INSERT INTO vacantes (puesto, descripcion) VALUES (?, ?)");
-    $stmt->bind_param('ss', $puesto, $descripcion);
-    $stmt->execute();
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['update_id'], $_POST['puesto'], $_POST['descripcion'])) {
+        $update_id = (int)$_POST['update_id'];
+        $puesto = trim($_POST['puesto']);
+        $descripcion = trim($_POST['descripcion']);
+        $stmt = $conn->prepare('UPDATE vacantes SET puesto = ?, descripcion = ? WHERE id = ?');
+        $stmt->bind_param('ssi', $puesto, $descripcion, $update_id);
+        $stmt->execute();
+    } elseif (isset($_POST['delete_id'])) {
+        $delete_id = (int)$_POST['delete_id'];
+        $stmt = $conn->prepare('DELETE FROM vacantes WHERE id = ?');
+        $stmt->bind_param('i', $delete_id);
+        $stmt->execute();
+    } elseif (isset($_POST['puesto'], $_POST['descripcion'])) {
+        $puesto = trim($_POST['puesto']);
+        $descripcion = trim($_POST['descripcion']);
+        $stmt = $conn->prepare('INSERT INTO vacantes (puesto, descripcion) VALUES (?, ?)');
+        $stmt->bind_param('ss', $puesto, $descripcion);
+        $stmt->execute();
+    }
 }
 
-$vacantes = $conn->query('SELECT puesto, descripcion FROM vacantes');
+$vacante_editar = null;
+if (isset($_GET['edit'])) {
+    $edit_id = (int)$_GET['edit'];
+    $stmt = $conn->prepare('SELECT id, puesto, descripcion FROM vacantes WHERE id = ?');
+    $stmt->bind_param('i', $edit_id);
+    $stmt->execute();
+    $vacante_editar = $stmt->get_result()->fetch_assoc();
+}
+$vacantes = $conn->query('SELECT id, puesto, descripcion FROM vacantes');
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -35,6 +57,18 @@ $vacantes = $conn->query('SELECT puesto, descripcion FROM vacantes');
     <main class="dashboard-content">
         <h1 id="vacantes">Vacantes</h1>
         <section>
+<?php if ($vacante_editar): ?>
+            <h3>Editar vacante</h3>
+            <form method="POST" action="dashboard.php">
+                <input type="hidden" name="update_id" value="<?php echo $vacante_editar['id']; ?>">
+                <label for="puesto_nuevo">Puesto:</label>
+                <input type="text" id="puesto_nuevo" name="puesto" required value="<?php echo htmlspecialchars($vacante_editar['puesto']); ?>">
+                <label for="descripcion_nueva">Descripci&oacute;n:</label>
+                <textarea id="descripcion_nueva" name="descripcion" required><?php echo htmlspecialchars($vacante_editar['descripcion']); ?></textarea>
+                <button type="submit">Actualizar</button>
+                <a href="dashboard.php">Cancelar</a>
+            </form>
+<?php else: ?>
             <h3>Agregar vacante</h3>
             <form method="POST" action="dashboard.php">
                 <label for="puesto_nuevo">Puesto:</label>
@@ -43,15 +77,23 @@ $vacantes = $conn->query('SELECT puesto, descripcion FROM vacantes');
                 <textarea id="descripcion_nueva" name="descripcion" required></textarea>
                 <button type="submit">Guardar</button>
             </form>
+<?php endif; ?>
         </section>
         <section>
             <h3>Listado de vacantes</h3>
             <table class="vacantes-table">
-                <tr><th>Puesto</th><th>Descripci&oacute;n</th></tr>
+                <tr><th>Puesto</th><th>Descripci&oacute;n</th><th>Acciones</th></tr>
                 <?php while($row = $vacantes->fetch_assoc()): ?>
                 <tr>
                     <td><?php echo htmlspecialchars($row['puesto']); ?></td>
                     <td><?php echo htmlspecialchars($row['descripcion']); ?></td>
+                    <td>
+                        <a href="dashboard.php?edit=<?php echo $row['id']; ?>">Editar</a>
+                        <form method="POST" action="dashboard.php" style="display:inline;">
+                            <input type="hidden" name="delete_id" value="<?php echo $row['id']; ?>">
+                            <button type="submit" onclick="return confirm('¿Eliminar vacante?');">Eliminar</button>
+                        </form>
+                    </td>
                 </tr>
                 <?php endwhile; ?>
             </table>


### PR DESCRIPTION
## Summary
- allow admins to update or remove vacancies
- show edit form when selecting a vacancy to modify
- support delete action
- document admin actions in README

## Testing
- `php -l dashboard.php`
- `php -l vacantes.php`
- `for f in *.php; do php -l "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_688aea4ea9508323b7c253f834d6fdf8