### PR TITLE
Add vacancy editing and deletion to admin dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ El usuario de ejemplo se llama `admin` y la contrase\xC3\xB1a es `admin123`.
 ## Uso
 
 - Accede a `login.php` e introduce las credenciales.
-- Tras iniciar sesi\xC3\xB3n se muestra el `dashboard.php`, donde podr\xC3\xA1s administrar las vacantes.
+- Tras iniciar sesi\xC3\xB3n se muestra el `dashboard.php`, donde podr\xC3\xA1s administrar las vacantes. Desde este panel puedes agregar, editar y eliminar registros.
 

--- a/dashboard.php
+++ b/dashboard.php
@@ -6,15 +6,39 @@ if (!isset($_SESSION['usuario_id'])) {
 }
 require_once 'conexion.php';
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['puesto'], $_POST['descripcion'])) {
-    $puesto = trim($_POST['puesto']);
-    $descripcion = trim($_POST['descripcion']);
-    $stmt = $conn->prepare("INSERT INTO vacantes (puesto, descripcion) VALUES (?, ?)");
-    $stmt->bind_param('ss', $puesto, $descripcion);
-    $stmt->execute();
+$edit_vacante = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if(isset($_POST['accion']) && $_POST['accion'] === 'editar' && isset($_POST['id'], $_POST['puesto'], $_POST['descripcion'])) {
+        $id = intval($_POST['id']);
+        $puesto = trim($_POST['puesto']);
+        $descripcion = trim($_POST['descripcion']);
+        $stmt = $conn->prepare('UPDATE vacantes SET puesto=?, descripcion=? WHERE id=?');
+        $stmt->bind_param('ssi', $puesto, $descripcion, $id);
+        $stmt->execute();
+    } elseif(isset($_POST['accion']) && $_POST['accion'] === 'eliminar' && isset($_POST['id'])) {
+        $id = intval($_POST['id']);
+        $stmt = $conn->prepare('DELETE FROM vacantes WHERE id=?');
+        $stmt->bind_param('i', $id);
+        $stmt->execute();
+    } elseif(isset($_POST['puesto'], $_POST['descripcion'])) {
+        $puesto = trim($_POST['puesto']);
+        $descripcion = trim($_POST['descripcion']);
+        $stmt = $conn->prepare('INSERT INTO vacantes (puesto, descripcion) VALUES (?, ?)');
+        $stmt->bind_param('ss', $puesto, $descripcion);
+        $stmt->execute();
+    }
 }
 
-$vacantes = $conn->query('SELECT puesto, descripcion FROM vacantes');
+if(isset($_GET['edit_id'])) {
+    $id = intval($_GET['edit_id']);
+    $stmt = $conn->prepare('SELECT id, puesto, descripcion FROM vacantes WHERE id=?');
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $edit_vacante = $stmt->get_result()->fetch_assoc();
+}
+
+$vacantes = $conn->query('SELECT id, puesto, descripcion FROM vacantes');
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -35,23 +59,38 @@ $vacantes = $conn->query('SELECT puesto, descripcion FROM vacantes');
     <main class="dashboard-content">
         <h1 id="vacantes">Vacantes</h1>
         <section>
-            <h3>Agregar vacante</h3>
+            <h3><?php echo $edit_vacante ? 'Editar vacante' : 'Agregar vacante'; ?></h3>
             <form method="POST" action="dashboard.php">
+                <?php if($edit_vacante): ?>
+                    <input type="hidden" name="accion" value="editar">
+                    <input type="hidden" name="id" value="<?php echo $edit_vacante['id']; ?>">
+                <?php endif; ?>
                 <label for="puesto_nuevo">Puesto:</label>
-                <input type="text" id="puesto_nuevo" name="puesto" required>
+                <input type="text" id="puesto_nuevo" name="puesto" required value="<?php echo $edit_vacante ? htmlspecialchars($edit_vacante['puesto']) : ''; ?>">
                 <label for="descripcion_nueva">Descripci&oacute;n:</label>
-                <textarea id="descripcion_nueva" name="descripcion" required></textarea>
+                <textarea id="descripcion_nueva" name="descripcion" required><?php echo $edit_vacante ? htmlspecialchars($edit_vacante['descripcion']) : ''; ?></textarea>
                 <button type="submit">Guardar</button>
+                <?php if($edit_vacante): ?>
+                    <a class="btn-vacantes" href="dashboard.php">Cancelar</a>
+                <?php endif; ?>
             </form>
         </section>
         <section>
             <h3>Listado de vacantes</h3>
             <table class="vacantes-table">
-                <tr><th>Puesto</th><th>Descripci&oacute;n</th></tr>
+                <tr><th>Puesto</th><th>Descripci&oacute;n</th><th>Acciones</th></tr>
                 <?php while($row = $vacantes->fetch_assoc()): ?>
                 <tr>
                     <td><?php echo htmlspecialchars($row['puesto']); ?></td>
                     <td><?php echo htmlspecialchars($row['descripcion']); ?></td>
+                    <td>
+                        <a class="btn-vacantes" href="dashboard.php?edit_id=<?php echo $row['id']; ?>">Editar</a>
+                        <form method="POST" action="dashboard.php" style="display:inline;">
+                            <input type="hidden" name="accion" value="eliminar">
+                            <input type="hidden" name="id" value="<?php echo $row['id']; ?>">
+                            <button type="submit" class="btn-vacantes" onclick="return confirm('¿Eliminar vacante?');">Eliminar</button>
+                        </form>
+                    </td>
                 </tr>
                 <?php endwhile; ?>
             </table>


### PR DESCRIPTION
## Summary
- enable admins to edit or delete vacancies
- update README with new admin capabilities

## Testing
- `php -l dashboard.php`
- `php -l vacantes.php`
- `php -l login.php`
- `php -l vacantes_internas.php`


------
https://chatgpt.com/codex/tasks/task_e_688aede5de1483239c49a0c453875f3b