### PR TITLE
Add applications storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Este proyecto es un sitio web simple desarrollado en PHP. Incluye un formulario 
 ## Configuraci\xC3\xB3n de la base de datos
 
 1. Crea una base de datos MySQL y un usuario con permisos. Las credenciales por defecto se encuentran en `conexion.php`.
-2. Ejecuta el script `sql/setup.sql` para crear las tablas necesarias (`usuarios` y `vacantes`) e insertar un usuario de ejemplo.
+2. Ejecuta el script `sql/setup.sql` para crear las tablas necesarias (`usuarios`, `vacantes` y `aplicaciones`) e insertar un usuario de ejemplo.
 
 ```bash
 mysql -u <usuario> -p < sql/setup.sql

--- a/aplicar.php
+++ b/aplicar.php
@@ -1,6 +1,17 @@
 <?php
 session_start();
-$puesto_solicitud = isset($_GET['puesto']) ? $_GET['puesto'] : '';
+require_once 'conexion.php';
+$vacante_id = isset($_GET['vacante_id']) ? intval($_GET['vacante_id']) : 0;
+$puesto_solicitud = '';
+if ($vacante_id > 0) {
+    $stmt = $conn->prepare('SELECT puesto FROM vacantes WHERE id = ?');
+    $stmt->bind_param('i', $vacante_id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    if ($row = $result->fetch_assoc()) {
+        $puesto_solicitud = $row['puesto'];
+    }
+}
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -45,6 +56,7 @@ $puesto_solicitud = isset($_GET['puesto']) ? $_GET['puesto'] : '';
     <section class="seccion">
       <h2>Enviar solicitud</h2>
       <form class="vacantes-form" action="enviar_vacantes.php" method="POST">
+        <input type="hidden" name="vacante_id" value="<?php echo $vacante_id; ?>">
         <label for="nombre">Nombre:</label>
         <input type="text" id="nombre" name="nombre" required>
 

--- a/enviar_vacantes.php
+++ b/enviar_vacantes.php
@@ -1,15 +1,21 @@
 <?php
+require_once 'conexion.php';
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $nombre = strip_tags(trim($_POST["nombre"]));
     $correo = filter_var(trim($_POST["correo"]), FILTER_SANITIZE_EMAIL);
     $telefono = strip_tags(trim($_POST["telefono"]));
     $puesto = strip_tags(trim($_POST["puesto"]));
     $mensaje = trim($_POST["mensaje"]);
+    $vacante_id = isset($_POST['vacante_id']) ? intval($_POST['vacante_id']) : 0;
 
     $destinatario = "reclutamiento@axtraltec.com";
     $asunto = "Solicitud de empleo";
     $contenido = "Nombre: $nombre\nCorreo: $correo\nTeléfono: $telefono\nPuesto de interés: $puesto\nMensaje:\n$mensaje";
     $encabezados = "From: $nombre <$correo>";
+
+    $stmt = $conn->prepare("INSERT INTO aplicaciones (vacante_id, nombre, correo, telefono, mensaje) VALUES (?, ?, ?, ?, ?)");
+    $stmt->bind_param('issss', $vacante_id, $nombre, $correo, $telefono, $mensaje);
+    $stmt->execute();
 
     if (mail($destinatario, $asunto, $contenido, $encabezados)) {
         echo "<script>alert('Informaci\xC3\xB3n enviada correctamente');window.history.back();</script>";

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -14,6 +14,17 @@ CREATE TABLE IF NOT EXISTS vacantes (
     descripcion TEXT NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS aplicaciones (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    vacante_id INT NOT NULL,
+    nombre VARCHAR(100) NOT NULL,
+    correo VARCHAR(100) NOT NULL,
+    telefono VARCHAR(50) NOT NULL,
+    mensaje TEXT NOT NULL,
+    fecha TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (vacante_id) REFERENCES vacantes(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 INSERT INTO usuarios (usuario, password, rol) VALUES
 ('admin', '$2y$12$rYFelBfwLsXPv0QWvEVpVu1ZXydP/3idi7FtK4Atn7WH/ZIi5rryS', 'administrador');
 

--- a/vacantes.php
+++ b/vacantes.php
@@ -60,7 +60,7 @@ $vacantes = $conn->query("SELECT id, puesto, descripcion FROM vacantes");
       <tr>
         <td><?php echo htmlspecialchars($row['puesto']); ?></td>
         <td><?php echo htmlspecialchars($row['descripcion']); ?></td>
-        <td><a class="btn-vacantes" href="aplicar.php?puesto=<?php echo urlencode($row['puesto']); ?>">Aplicar</a></td>
+        <td><a class="btn-vacantes" href="aplicar.php?vacante_id=<?php echo $row['id']; ?>">Aplicar</a></td>
       </tr>
       <?php endwhile; ?>
     </table>


### PR DESCRIPTION
## Summary
- create `aplicaciones` table in setup script
- insert job application data into new table
- pass and handle `vacante_id` when applying to a vacancy
- document new table in README

## Testing
- `php -l aplicar.php`
- `php -l enviar_vacantes.php`
- `php -l vacantes.php`

------
https://chatgpt.com/codex/tasks/task_e_688aee1d8cd48323a9e6177b45279652