### PR TITLE
Amplia datos de vacantes

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -13,8 +13,15 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $id = intval($_POST['id']);
         $puesto = trim($_POST['puesto']);
         $descripcion = trim($_POST['descripcion']);
-        $stmt = $conn->prepare('UPDATE vacantes SET puesto=?, descripcion=? WHERE id=?');
-        $stmt->bind_param('ssi', $puesto, $descripcion, $id);
+        $ubicacion = trim($_POST['ubicacion']);
+        $sueldo = trim($_POST['sueldo']);
+        $horario = trim($_POST['horario']);
+        $requisitos = trim($_POST['requisitos']);
+        $tipo_contrato = trim($_POST['tipo_contrato']);
+        $fecha_publicacion = trim($_POST['fecha_publicacion']);
+        $estado = trim($_POST['estado']);
+        $stmt = $conn->prepare('UPDATE vacantes SET puesto=?, descripcion=?, ubicacion=?, sueldo=?, horario=?, requisitos=?, tipo_contrato=?, fecha_publicacion=?, estado=? WHERE id=?');
+        $stmt->bind_param('sssssssssi', $puesto, $descripcion, $ubicacion, $sueldo, $horario, $requisitos, $tipo_contrato, $fecha_publicacion, $estado, $id);
         $stmt->execute();
     } elseif(isset($_POST['accion']) && $_POST['accion'] === 'eliminar' && isset($_POST['id'])) {
         $id = intval($_POST['id']);
@@ -24,21 +31,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif(isset($_POST['puesto'], $_POST['descripcion'])) {
         $puesto = trim($_POST['puesto']);
         $descripcion = trim($_POST['descripcion']);
-        $stmt = $conn->prepare('INSERT INTO vacantes (puesto, descripcion) VALUES (?, ?)');
-        $stmt->bind_param('ss', $puesto, $descripcion);
+        $ubicacion = trim($_POST['ubicacion']);
+        $sueldo = trim($_POST['sueldo']);
+        $horario = trim($_POST['horario']);
+        $requisitos = trim($_POST['requisitos']);
+        $tipo_contrato = trim($_POST['tipo_contrato']);
+        $fecha_publicacion = trim($_POST['fecha_publicacion']);
+        $estado = trim($_POST['estado']);
+        $stmt = $conn->prepare('INSERT INTO vacantes (puesto, descripcion, ubicacion, sueldo, horario, requisitos, tipo_contrato, fecha_publicacion, estado) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
+        $stmt->bind_param('sssssssss', $puesto, $descripcion, $ubicacion, $sueldo, $horario, $requisitos, $tipo_contrato, $fecha_publicacion, $estado);
         $stmt->execute();
     }
 }
 
 if(isset($_GET['edit_id'])) {
     $id = intval($_GET['edit_id']);
-    $stmt = $conn->prepare('SELECT id, puesto, descripcion FROM vacantes WHERE id=?');
+    $stmt = $conn->prepare('SELECT id, puesto, descripcion, ubicacion, sueldo, horario, requisitos, tipo_contrato, fecha_publicacion, estado FROM vacantes WHERE id=?');
     $stmt->bind_param('i', $id);
     $stmt->execute();
     $edit_vacante = $stmt->get_result()->fetch_assoc();
 }
 
-$vacantes = $conn->query('SELECT id, puesto, descripcion FROM vacantes');
+$vacantes = $conn->query('SELECT id, puesto, descripcion, ubicacion, sueldo, horario, requisitos, tipo_contrato, fecha_publicacion, estado FROM vacantes');
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -69,6 +83,20 @@ $vacantes = $conn->query('SELECT id, puesto, descripcion FROM vacantes');
                 <input type="text" id="puesto_nuevo" name="puesto" required value="<?php echo $edit_vacante ? htmlspecialchars($edit_vacante['puesto']) : ''; ?>">
                 <label for="descripcion_nueva">Descripci&oacute;n:</label>
                 <textarea id="descripcion_nueva" name="descripcion" required><?php echo $edit_vacante ? htmlspecialchars($edit_vacante['descripcion']) : ''; ?></textarea>
+                <label for="ubicacion">Ubicaci&oacute;n:</label>
+                <input type="text" id="ubicacion" name="ubicacion" required value="<?php echo $edit_vacante ? htmlspecialchars($edit_vacante['ubicacion']) : ''; ?>">
+                <label for="sueldo">Sueldo:</label>
+                <input type="text" id="sueldo" name="sueldo" required value="<?php echo $edit_vacante ? htmlspecialchars($edit_vacante['sueldo']) : ''; ?>">
+                <label for="horario">Horario:</label>
+                <input type="text" id="horario" name="horario" required value="<?php echo $edit_vacante ? htmlspecialchars($edit_vacante['horario']) : ''; ?>">
+                <label for="requisitos">Requisitos:</label>
+                <textarea id="requisitos" name="requisitos" required><?php echo $edit_vacante ? htmlspecialchars($edit_vacante['requisitos']) : ''; ?></textarea>
+                <label for="tipo_contrato">Tipo de contrato:</label>
+                <input type="text" id="tipo_contrato" name="tipo_contrato" required value="<?php echo $edit_vacante ? htmlspecialchars($edit_vacante['tipo_contrato']) : ''; ?>">
+                <label for="fecha_publicacion">Fecha de publicaci&oacute;n:</label>
+                <input type="date" id="fecha_publicacion" name="fecha_publicacion" required value="<?php echo $edit_vacante ? htmlspecialchars($edit_vacante['fecha_publicacion']) : ''; ?>">
+                <label for="estado">Estado:</label>
+                <input type="text" id="estado" name="estado" required value="<?php echo $edit_vacante ? htmlspecialchars($edit_vacante['estado']) : ''; ?>">
                 <button type="submit">Guardar</button>
                 <?php if($edit_vacante): ?>
                     <a class="btn-vacantes" href="dashboard.php">Cancelar</a>
@@ -78,10 +106,22 @@ $vacantes = $conn->query('SELECT id, puesto, descripcion FROM vacantes');
         <section>
             <h3>Listado de vacantes</h3>
             <table class="vacantes-table">
-                <tr><th>Puesto</th><th>Descripci&oacute;n</th><th>Acciones</th></tr>
+                <tr>
+                    <th>Puesto</th>
+                    <th>Ubicaci&oacute;n</th>
+                    <th>Sueldo</th>
+                    <th>Horario</th>
+                    <th>Tipo de contrato</th>
+                    <th>Descripci&oacute;n</th>
+                    <th>Acciones</th>
+                </tr>
                 <?php while($row = $vacantes->fetch_assoc()): ?>
                 <tr>
                     <td><?php echo htmlspecialchars($row['puesto']); ?></td>
+                    <td><?php echo htmlspecialchars($row['ubicacion']); ?></td>
+                    <td><?php echo htmlspecialchars($row['sueldo']); ?></td>
+                    <td><?php echo htmlspecialchars($row['horario']); ?></td>
+                    <td><?php echo htmlspecialchars($row['tipo_contrato']); ?></td>
                     <td><?php echo htmlspecialchars($row['descripcion']); ?></td>
                     <td>
                         <a class="btn-vacantes" href="dashboard.php?edit_id=<?php echo $row['id']; ?>">Editar</a>

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -11,7 +11,14 @@ CREATE TABLE IF NOT EXISTS usuarios (
 CREATE TABLE IF NOT EXISTS vacantes (
     id INT AUTO_INCREMENT PRIMARY KEY,
     puesto VARCHAR(100) NOT NULL,
-    descripcion TEXT NOT NULL
+    descripcion TEXT NOT NULL,
+    ubicacion VARCHAR(100) DEFAULT NULL,
+    sueldo VARCHAR(50) DEFAULT NULL,
+    horario VARCHAR(100) DEFAULT NULL,
+    requisitos TEXT DEFAULT NULL,
+    tipo_contrato VARCHAR(50) DEFAULT NULL,
+    fecha_publicacion DATE DEFAULT NULL,
+    estado VARCHAR(50) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS aplicaciones (
@@ -28,5 +35,5 @@ CREATE TABLE IF NOT EXISTS aplicaciones (
 INSERT INTO usuarios (usuario, password, rol) VALUES
 ('admin', '$2y$12$rYFelBfwLsXPv0QWvEVpVu1ZXydP/3idi7FtK4Atn7WH/ZIi5rryS', 'administrador');
 
-INSERT INTO vacantes (puesto, descripcion) VALUES
-('Ejemplo de puesto', 'Ejemplo de descripcion');
+INSERT INTO vacantes (puesto, descripcion, ubicacion, sueldo, horario, requisitos, tipo_contrato, fecha_publicacion, estado) VALUES
+('Ejemplo de puesto', 'Ejemplo de descripcion', 'CDMX', 'A convenir', 'Lunes a Viernes', 'Experiencia de ejemplo', 'Tiempo completo', CURDATE(), 'Activa');

--- a/vacantes.php
+++ b/vacantes.php
@@ -5,12 +5,19 @@ require_once "conexion.php";
 if(isset($_SESSION['usuario_id']) && $_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['puesto'], $_POST['descripcion'])) {
     $puesto = trim($_POST['puesto']);
     $descripcion = trim($_POST['descripcion']);
-    $stmt = $conn->prepare("INSERT INTO vacantes (puesto, descripcion) VALUES (?, ?)");
-    $stmt->bind_param('ss', $puesto, $descripcion);
+    $ubicacion = trim($_POST['ubicacion']);
+    $sueldo = trim($_POST['sueldo']);
+    $horario = trim($_POST['horario']);
+    $requisitos = trim($_POST['requisitos']);
+    $tipo_contrato = trim($_POST['tipo_contrato']);
+    $fecha_publicacion = trim($_POST['fecha_publicacion']);
+    $estado = trim($_POST['estado']);
+    $stmt = $conn->prepare("INSERT INTO vacantes (puesto, descripcion, ubicacion, sueldo, horario, requisitos, tipo_contrato, fecha_publicacion, estado) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)");
+    $stmt->bind_param('sssssssss', $puesto, $descripcion, $ubicacion, $sueldo, $horario, $requisitos, $tipo_contrato, $fecha_publicacion, $estado);
     $stmt->execute();
 }
 
-$vacantes = $conn->query("SELECT id, puesto, descripcion FROM vacantes");
+$vacantes = $conn->query("SELECT id, puesto, descripcion, ubicacion, sueldo, horario, requisitos, tipo_contrato, fecha_publicacion, estado FROM vacantes");
 
 ?>
 <!DOCTYPE html>
@@ -55,10 +62,22 @@ $vacantes = $conn->query("SELECT id, puesto, descripcion FROM vacantes");
   <main>
     <h1>Vacantes disponibles</h1>
     <table class="vacantes-table">
-      <tr><th>Puesto</th><th>Descripci&oacute;n</th><th></th></tr>
+      <tr>
+        <th>Puesto</th>
+        <th>Ubicaci&oacute;n</th>
+        <th>Sueldo</th>
+        <th>Horario</th>
+        <th>Tipo de contrato</th>
+        <th>Descripci&oacute;n</th>
+        <th></th>
+      </tr>
       <?php while($row = $vacantes->fetch_assoc()): ?>
       <tr>
         <td><?php echo htmlspecialchars($row['puesto']); ?></td>
+        <td><?php echo htmlspecialchars($row['ubicacion']); ?></td>
+        <td><?php echo htmlspecialchars($row['sueldo']); ?></td>
+        <td><?php echo htmlspecialchars($row['horario']); ?></td>
+        <td><?php echo htmlspecialchars($row['tipo_contrato']); ?></td>
         <td><?php echo htmlspecialchars($row['descripcion']); ?></td>
         <td><a class="btn-vacantes" href="aplicar.php?vacante_id=<?php echo $row['id']; ?>">Aplicar</a></td>
       </tr>
@@ -67,7 +86,7 @@ $vacantes = $conn->query("SELECT id, puesto, descripcion FROM vacantes");
 
 
 <?php if(isset($_SESSION['usuario_id'])): ?>
-<?php $vacantes_admin = $conn->query("SELECT puesto, descripcion FROM vacantes"); ?>
+<?php $vacantes_admin = $conn->query("SELECT puesto, descripcion, ubicacion, sueldo, horario, requisitos, tipo_contrato, fecha_publicacion, estado FROM vacantes"); ?>
 <section class="seccion">
   <h3>Agregar vacante</h3>
   <form method="POST" action="vacantes.php">
@@ -75,16 +94,41 @@ $vacantes = $conn->query("SELECT id, puesto, descripcion FROM vacantes");
     <input type="text" id="puesto_nuevo" name="puesto" required>
     <label for="descripcion_nueva">Descripci&oacute;n:</label>
     <textarea id="descripcion_nueva" name="descripcion" required></textarea>
+    <label for="ubicacion">Ubicaci&oacute;n:</label>
+    <input type="text" id="ubicacion" name="ubicacion" required>
+    <label for="sueldo">Sueldo:</label>
+    <input type="text" id="sueldo" name="sueldo" required>
+    <label for="horario">Horario:</label>
+    <input type="text" id="horario" name="horario" required>
+    <label for="requisitos">Requisitos:</label>
+    <textarea id="requisitos" name="requisitos" required></textarea>
+    <label for="tipo_contrato">Tipo de contrato:</label>
+    <input type="text" id="tipo_contrato" name="tipo_contrato" required>
+    <label for="fecha_publicacion">Fecha de publicaci&oacute;n:</label>
+    <input type="date" id="fecha_publicacion" name="fecha_publicacion" required>
+    <label for="estado">Estado:</label>
+    <input type="text" id="estado" name="estado" required>
     <button type="submit">Guardar</button>
   </form>
 </section>
 <section class="seccion">
   <h3>Listado de vacantes</h3>
   <table class="vacantes-table">
-    <tr><th>Puesto</th><th>Descripci&oacute;n</th></tr>
+    <tr>
+      <th>Puesto</th>
+      <th>Ubicaci&oacute;n</th>
+      <th>Sueldo</th>
+      <th>Horario</th>
+      <th>Tipo de contrato</th>
+      <th>Descripci&oacute;n</th>
+    </tr>
     <?php while($row = $vacantes_admin->fetch_assoc()): ?>
     <tr>
       <td><?php echo htmlspecialchars($row['puesto']); ?></td>
+      <td><?php echo htmlspecialchars($row['ubicacion']); ?></td>
+      <td><?php echo htmlspecialchars($row['sueldo']); ?></td>
+      <td><?php echo htmlspecialchars($row['horario']); ?></td>
+      <td><?php echo htmlspecialchars($row['tipo_contrato']); ?></td>
       <td><?php echo htmlspecialchars($row['descripcion']); ?></td>
     </tr>
     <?php endwhile; ?>

--- a/vacantes_internas.php
+++ b/vacantes_internas.php
@@ -6,7 +6,7 @@ if (!isset($_SESSION['usuario_id'])) {
 }
 require_once 'conexion.php';
 
-$stmt = $conn->prepare('SELECT puesto, descripcion FROM vacantes');
+$stmt = $conn->prepare('SELECT puesto, descripcion, ubicacion, sueldo, horario, requisitos, tipo_contrato, fecha_publicacion, estado FROM vacantes');
 $stmt->execute();
 $result = $stmt->get_result();
 ?>
@@ -22,11 +22,26 @@ $result = $stmt->get_result();
     <h2>Vacantes internas</h2>
     <p>Bienvenido, <?php echo htmlspecialchars($_SESSION['rol']); ?>.</p>
     <a href="logout.php">Cerrar sesi&oacute;n</a>
-    <ul>
-    <?php while ($vac = $result->fetch_assoc()): ?>
-        <li><strong><?php echo htmlspecialchars($vac['puesto']); ?></strong>: <?php echo htmlspecialchars($vac['descripcion']); ?></li>
-    <?php endwhile; ?>
-    </ul>
+    <table class="vacantes-table">
+        <tr>
+            <th>Puesto</th>
+            <th>Ubicaci&oacute;n</th>
+            <th>Sueldo</th>
+            <th>Horario</th>
+            <th>Tipo de contrato</th>
+            <th>Descripci&oacute;n</th>
+        </tr>
+        <?php while ($vac = $result->fetch_assoc()): ?>
+        <tr>
+            <td><?php echo htmlspecialchars($vac['puesto']); ?></td>
+            <td><?php echo htmlspecialchars($vac['ubicacion']); ?></td>
+            <td><?php echo htmlspecialchars($vac['sueldo']); ?></td>
+            <td><?php echo htmlspecialchars($vac['horario']); ?></td>
+            <td><?php echo htmlspecialchars($vac['tipo_contrato']); ?></td>
+            <td><?php echo htmlspecialchars($vac['descripcion']); ?></td>
+        </tr>
+        <?php endwhile; ?>
+    </table>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ampliar el esquema de `vacantes` con más campos
- permitir registrar todos los campos en las vacantes
- mostrar los nuevos datos en los listados de vacantes y en el dashboard

## Testing
- `php -l vacantes.php`
- `php -l dashboard.php`
- `php -l vacantes_internas.php`

------
https://chatgpt.com/codex/tasks/task_e_688af06ffd2c8323b5286fda94732651