### PR TITLE
Add curriculum upload to job applications

### DIFF
--- a/aplicaciones.php
+++ b/aplicaciones.php
@@ -6,7 +6,7 @@ if (!isset($_SESSION['usuario_id'])) {
 }
 require_once 'conexion.php';
 
-$applications = $conn->query("SELECT a.id, v.puesto, a.nombre, a.correo, a.telefono, a.mensaje, a.fecha FROM aplicaciones a JOIN vacantes v ON a.vacante_id = v.id ORDER BY a.fecha DESC");
+$applications = $conn->query("SELECT a.id, v.puesto, a.nombre, a.correo, a.telefono, a.curriculum, a.mensaje, a.fecha FROM aplicaciones a JOIN vacantes v ON a.vacante_id = v.id ORDER BY a.fecha DESC");
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -33,6 +33,7 @@ $applications = $conn->query("SELECT a.id, v.puesto, a.nombre, a.correo, a.telef
                 <th>Nombre</th>
                 <th>Correo</th>
                 <th>Tel&eacute;fono</th>
+                <th>Curr&iacute;culum</th>
                 <th>Mensaje</th>
                 <th>Fecha</th>
             </tr>
@@ -42,6 +43,13 @@ $applications = $conn->query("SELECT a.id, v.puesto, a.nombre, a.correo, a.telef
                 <td><?php echo htmlspecialchars($row['nombre']); ?></td>
                 <td><?php echo htmlspecialchars($row['correo']); ?></td>
                 <td><?php echo htmlspecialchars($row['telefono']); ?></td>
+                <td>
+                    <?php if ($row['curriculum']): ?>
+                        <a href="<?php echo htmlspecialchars($row['curriculum']); ?>" target="_blank">Ver</a>
+                    <?php else: ?>
+                        N/A
+                    <?php endif; ?>
+                </td>
                 <td><?php echo nl2br(htmlspecialchars($row['mensaje'])); ?></td>
                 <td><?php echo htmlspecialchars($row['fecha']); ?></td>
             </tr>

--- a/aplicar.php
+++ b/aplicar.php
@@ -55,7 +55,7 @@ if ($vacante_id > 0) {
   <main>
     <section class="seccion">
       <h2>Enviar solicitud</h2>
-      <form class="vacantes-form" action="enviar_vacantes.php" method="POST">
+      <form class="vacantes-form" action="enviar_vacantes.php" method="POST" enctype="multipart/form-data">
         <input type="hidden" name="vacante_id" value="<?php echo $vacante_id; ?>">
         <label for="nombre">Nombre:</label>
         <input type="text" id="nombre" name="nombre" required>
@@ -68,6 +68,9 @@ if ($vacante_id > 0) {
 
         <label for="puesto">Puesto de inter&eacute;s:</label>
         <input type="text" id="puesto" name="puesto" required value="<?php echo htmlspecialchars($puesto_solicitud); ?>">
+
+        <label for="curriculum">Curr&iacute;culum (PDF o DOC):</label>
+        <input type="file" id="curriculum" name="curriculum" accept=".pdf,.doc,.docx" required>
 
         <label for="mensaje">Mensaje:</label>
         <textarea id="mensaje" name="mensaje" rows="4" required></textarea>

--- a/enviar_vacantes.php
+++ b/enviar_vacantes.php
@@ -6,15 +6,31 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $telefono = strip_tags(trim($_POST["telefono"]));
     $puesto = strip_tags(trim($_POST["puesto"]));
     $mensaje = trim($_POST["mensaje"]);
+
+    $curriculum_path = null;
+    if (isset($_FILES['curriculum']) && $_FILES['curriculum']['error'] === UPLOAD_ERR_OK) {
+        $targetDir = __DIR__ . '/uploads/';
+        if (!is_dir($targetDir)) {
+            mkdir($targetDir, 0755, true);
+        }
+        $fileName = uniqid('', true) . '-' . basename($_FILES['curriculum']['name']);
+        $targetFile = $targetDir . $fileName;
+        if (move_uploaded_file($_FILES['curriculum']['tmp_name'], $targetFile)) {
+            $curriculum_path = 'uploads/' . $fileName;
+        }
+    }
     $vacante_id = isset($_POST['vacante_id']) ? intval($_POST['vacante_id']) : 0;
 
     $destinatario = "reclutamiento@axtraltec.com";
     $asunto = "Solicitud de empleo";
     $contenido = "Nombre: $nombre\nCorreo: $correo\nTeléfono: $telefono\nPuesto de interés: $puesto\nMensaje:\n$mensaje";
+    if ($curriculum_path) {
+        $contenido .= "\nCurrículum: $curriculum_path";
+    }
     $encabezados = "From: $nombre <$correo>";
 
-    $stmt = $conn->prepare("INSERT INTO aplicaciones (vacante_id, nombre, correo, telefono, mensaje) VALUES (?, ?, ?, ?, ?)");
-    $stmt->bind_param('issss', $vacante_id, $nombre, $correo, $telefono, $mensaje);
+    $stmt = $conn->prepare("INSERT INTO aplicaciones (vacante_id, nombre, correo, telefono, curriculum, mensaje) VALUES (?, ?, ?, ?, ?, ?)");
+    $stmt->bind_param('isssss', $vacante_id, $nombre, $correo, $telefono, $curriculum_path, $mensaje);
     $stmt->execute();
 
     if (mail($destinatario, $asunto, $contenido, $encabezados)) {

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS aplicaciones (
     nombre VARCHAR(100) NOT NULL,
     correo VARCHAR(100) NOT NULL,
     telefono VARCHAR(50) NOT NULL,
+    curriculum VARCHAR(255) DEFAULT NULL,
     mensaje TEXT NOT NULL,
     fecha TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (vacante_id) REFERENCES vacantes(id)


### PR DESCRIPTION
## Summary
- add `curriculum` column to applications table
- allow uploading a curriculum in `aplicar.php`
- save uploaded file in `enviar_vacantes.php` and store its path
- show curriculum link in admin `aplicaciones.php`
- keep uploads directory in repo

## Testing
- `php -l aplicar.php`
- `php -l enviar_vacantes.php`
- `php -l aplicaciones.php`


------
https://chatgpt.com/codex/tasks/task_e_688af8a9422483239ef13bc5193ff018