### PR TITLE
Add Servicios and Transparencia pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sitio PEMEX
 
-Este proyecto es un sitio web simple desarrollado en PHP. Incluye un formulario de inicio de sesi\xC3\xB3n que valida las credenciales contra una base de datos MySQL.
+Este proyecto es un sitio web simple desarrollado en PHP. Incluye un formulario de inicio de sesión que valida las credenciales contra una base de datos MySQL. El portal cuenta con secciones de Historia, Misión, Principios y nuevas páginas de **Servicios** y **Transparencia** para consultar la información corporativa esencial.
 
 ## Configuraci\xC3\xB3n de la base de datos
 

--- a/contacto.php
+++ b/contacto.php
@@ -25,6 +25,8 @@
         <li><a href="historia.php">Historia</a></li>
         <li><a href="mision.php">Misión y Visión</a></li>
         <li><a href="principios.php">Principios</a></li>
+        <li><a href="servicios.php">Servicios</a></li>
+        <li><a href="transparencia.php">Transparencia</a></li>
             </ul>
         </li>
         <li><a href="vacantes.php">Vacantes</a></li>

--- a/historia.php
+++ b/historia.php
@@ -25,6 +25,8 @@
         <li><a href="historia.php">Historia</a></li>
         <li><a href="mision.php">Misión y Visión</a></li>
         <li><a href="principios.php">Principios</a></li>
+        <li><a href="servicios.php">Servicios</a></li>
+        <li><a href="transparencia.php">Transparencia</a></li>
             </ul>
         </li>
         <li><a href="vacantes.php">Vacantes</a></li>

--- a/index.php
+++ b/index.php
@@ -25,6 +25,8 @@
         <li><a href="historia.php">Historia</a></li>
         <li><a href="mision.php">Misión y Visión</a></li>
         <li><a href="principios.php">Principios</a></li>
+        <li><a href="servicios.php">Servicios</a></li>
+        <li><a href="transparencia.php">Transparencia</a></li>
         </ul></li>
         <li><a href="vacantes.php">Vacantes</a></li>
         <li><a href="contacto.php">Contacto</a></li>

--- a/mision.php
+++ b/mision.php
@@ -25,6 +25,8 @@
         <li><a href="historia.php">Historia</a></li>
         <li><a href="mision.php">Misión y Visión</a></li>
         <li><a href="principios.php">Principios</a></li>
+        <li><a href="servicios.php">Servicios</a></li>
+        <li><a href="transparencia.php">Transparencia</a></li>
             </ul>
         </li>
         <li><a href="vacantes.php">Vacantes</a></li>

--- a/principios.php
+++ b/principios.php
@@ -25,6 +25,8 @@
         <li><a href="historia.php">Historia</a></li>
         <li><a href="mision.php">Misión y Visión</a></li>
         <li><a href="principios.php">Principios</a></li>
+        <li><a href="servicios.php">Servicios</a></li>
+        <li><a href="transparencia.php">Transparencia</a></li>
             </ul>
         </li>
         <li><a href="vacantes.php">Vacantes</a></li>

--- a/servicios.php
+++ b/servicios.php
@@ -1,28 +1,14 @@
-<?php
-session_start();
-require_once 'conexion.php';
-$vacante_id = isset($_GET['vacante_id']) ? intval($_GET['vacante_id']) : 0;
-$puesto_solicitud = '';
-if ($vacante_id > 0) {
-    $stmt = $conn->prepare('SELECT puesto FROM vacantes WHERE id = ?');
-    $stmt->bind_param('i', $vacante_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    if ($row = $result->fetch_assoc()) {
-        $puesto_solicitud = $row['puesto'];
-    }
-}
-?>
+<?php session_start(); ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
   <meta charset="UTF-8">
-  <title>PEMEX | Aplicar</title>
+  <title>PEMEX | Servicios</title>
   <link rel="icon" href="img/favicon.ico" type="image/x-icon">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body class="vacantes-page">
+<body>
   <div id="preloader">Cargando sitio...</div>
   <header>
     <div class="logo"><img src="img/logo.png" alt="Pemex" style="height: 66px;"></div>
@@ -55,27 +41,24 @@ if ($vacante_id > 0) {
     </nav>
   </header>
   <main>
-    <section class="seccion">
-      <h2>Enviar solicitud</h2>
-      <form class="vacantes-form" action="enviar_vacantes.php" method="POST">
-        <input type="hidden" name="vacante_id" value="<?php echo $vacante_id; ?>">
-        <label for="nombre">Nombre:</label>
-        <input type="text" id="nombre" name="nombre" required>
-
-        <label for="correo">Correo:</label>
-        <input type="email" id="correo" name="correo" required>
-
-        <label for="telefono">Tel&eacute;fono:</label>
-        <input type="tel" id="telefono" name="telefono" required>
-
-        <label for="puesto">Puesto de inter&eacute;s:</label>
-        <input type="text" id="puesto" name="puesto" required value="<?php echo htmlspecialchars($puesto_solicitud); ?>">
-
-        <label for="mensaje">Mensaje:</label>
-        <textarea id="mensaje" name="mensaje" rows="4" required></textarea>
-
-        <button type="submit">Enviar</button>
-      </form>
+    <section class="parallax-historia">
+      <div class="contenido-parallax">
+        <h2>Nuestros Servicios</h2>
+      </div>
+    </section>
+    <section class="historia-contenido">
+      <div class="historia-imagen">
+        <img src="img/ic2.png" alt="Servicios">
+      </div>
+      <div class="historia-texto">
+        <p>Pemex ofrece servicios integrales que abarcan la cadena de valor de los hidrocarburos.</p>
+        <ul>
+          <li>Exploración y producción</li>
+          <li>Transformación industrial</li>
+          <li>Logística y distribución</li>
+          <li>Comercialización de combustibles y petroquímicos</li>
+        </ul>
+      </div>
     </section>
   </main>
   <footer>

--- a/transparencia.php
+++ b/transparencia.php
@@ -1,28 +1,14 @@
-<?php
-session_start();
-require_once 'conexion.php';
-$vacante_id = isset($_GET['vacante_id']) ? intval($_GET['vacante_id']) : 0;
-$puesto_solicitud = '';
-if ($vacante_id > 0) {
-    $stmt = $conn->prepare('SELECT puesto FROM vacantes WHERE id = ?');
-    $stmt->bind_param('i', $vacante_id);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    if ($row = $result->fetch_assoc()) {
-        $puesto_solicitud = $row['puesto'];
-    }
-}
-?>
+<?php session_start(); ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
   <meta charset="UTF-8">
-  <title>PEMEX | Aplicar</title>
+  <title>PEMEX | Transparencia</title>
   <link rel="icon" href="img/favicon.ico" type="image/x-icon">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="css/style.css">
 </head>
-<body class="vacantes-page">
+<body>
   <div id="preloader">Cargando sitio...</div>
   <header>
     <div class="logo"><img src="img/logo.png" alt="Pemex" style="height: 66px;"></div>
@@ -55,27 +41,19 @@ if ($vacante_id > 0) {
     </nav>
   </header>
   <main>
-    <section class="seccion">
-      <h2>Enviar solicitud</h2>
-      <form class="vacantes-form" action="enviar_vacantes.php" method="POST">
-        <input type="hidden" name="vacante_id" value="<?php echo $vacante_id; ?>">
-        <label for="nombre">Nombre:</label>
-        <input type="text" id="nombre" name="nombre" required>
-
-        <label for="correo">Correo:</label>
-        <input type="email" id="correo" name="correo" required>
-
-        <label for="telefono">Tel&eacute;fono:</label>
-        <input type="tel" id="telefono" name="telefono" required>
-
-        <label for="puesto">Puesto de inter&eacute;s:</label>
-        <input type="text" id="puesto" name="puesto" required value="<?php echo htmlspecialchars($puesto_solicitud); ?>">
-
-        <label for="mensaje">Mensaje:</label>
-        <textarea id="mensaje" name="mensaje" rows="4" required></textarea>
-
-        <button type="submit">Enviar</button>
-      </form>
+    <section class="parallax-historia">
+      <div class="contenido-parallax">
+        <h2>Transparencia</h2>
+      </div>
+    </section>
+    <section class="historia-contenido">
+      <div class="historia-imagen">
+        <img src="img/ic4.png" alt="Transparencia">
+      </div>
+      <div class="historia-texto">
+        <p>En Pemex estamos comprometidos con la rendición de cuentas y la disponibilidad de información pública.</p>
+        <p>Consulta reportes financieros, auditorías y normativa vigente en nuestro portal de transparencia.</p>
+      </div>
     </section>
   </main>
   <footer>

--- a/vacantes.php
+++ b/vacantes.php
@@ -46,6 +46,8 @@ $vacantes = $conn ? $conn->query("SELECT id, puesto, descripcion, ubicacion, sue
         <li><a href="historia.php">Historia</a></li>
         <li><a href="mision.php">Misión y Visión</a></li>
         <li><a href="principios.php">Principios</a></li>
+        <li><a href="servicios.php">Servicios</a></li>
+        <li><a href="transparencia.php">Transparencia</a></li>
             </ul>
         </li>
 <li><a href="vacantes.php">Vacantes</a></li>


### PR DESCRIPTION
## Summary
- create new sections: Servicios and Transparencia
- link new pages from navigation menus
- update README with info about new sections

## Testing
- `php -l servicios.php`
- `php -l transparencia.php`
- `php -l index.php`
- `php -l historia.php`
- `php -l mision.php`
- `php -l principios.php`
- `php -l contacto.php`
- `php -l aplicar.php`
- `php -l vacantes.php`


------
https://chatgpt.com/codex/tasks/task_e_688af8c1d8188323abd92f3d27a2740b