### PR TITLE
Agregar soporte de departamentos en quejas

### DIFF
--- a/enviar_queja.php
+++ b/enviar_queja.php
@@ -5,7 +5,7 @@ require_once 'conexion.php';
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $nombre = strip_tags(trim($_POST['nombre']));
     $correo = filter_var(trim($_POST['correo']), FILTER_SANITIZE_EMAIL);
-    $destino = strip_tags(trim($_POST['destino']));
+    $departamento_id = intval($_POST['departamento_id']);
     $mensaje = trim($_POST['mensaje']);
     $captcha = intval($_POST['captcha']);
 
@@ -15,8 +15,8 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     }
 
     if ($conn) {
-        $stmt = $conn->prepare("INSERT INTO quejas (nombre, correo, destino, mensaje) VALUES (?, ?, ?, ?)");
-        $stmt->bind_param('ssss', $nombre, $correo, $destino, $mensaje);
+        $stmt = $conn->prepare("INSERT INTO quejas (nombre, correo, departamento_id, mensaje) VALUES (?, ?, ?, ?)");
+        $stmt->bind_param('ssis', $nombre, $correo, $departamento_id, $mensaje);
         $stmt->execute();
     }
     echo "<script>alert('Queja enviada correctamente');window.location.href='index.php';</script>";

--- a/quejas.php
+++ b/quejas.php
@@ -1,8 +1,11 @@
 <?php
 session_start();
+require_once 'conexion.php';
 $captcha_a = rand(1,5);
 $captcha_b = rand(1,5);
 $_SESSION['captcha_sum'] = $captcha_a + $captcha_b;
+
+$departamentos = $conn ? $conn->query("SELECT id, nombre FROM departamentos ORDER BY nombre") : null;
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -55,7 +58,13 @@ $_SESSION['captcha_sum'] = $captcha_a + $captcha_b;
         <label for="correo">Correo:</label>
         <input type="email" id="correo" name="correo" required>
         <label for="destino">Dirigido a:</label>
-        <input type="text" id="destino" name="destino" required>
+        <select id="destino" name="departamento_id" required>
+        <?php if($departamentos): ?>
+          <?php while($dep = $departamentos->fetch_assoc()): ?>
+            <option value="<?php echo $dep['id']; ?>"><?php echo htmlspecialchars($dep['nombre']); ?></option>
+          <?php endwhile; ?>
+        <?php endif; ?>
+        </select>
         <label for="mensaje">Queja:</label>
         <textarea id="mensaje" name="mensaje" rows="4" required></textarea>
         <label for="captcha">¿Cuánto es <?php echo $captcha_a; ?> + <?php echo $captcha_b; ?>?</label>

--- a/quejas_admin.php
+++ b/quejas_admin.php
@@ -6,7 +6,17 @@ if (!isset($_SESSION['usuario_id'])) {
 }
 require_once 'conexion.php';
 
-$quejas = $conn->query("SELECT id, nombre, correo, destino, mensaje, fecha FROM quejas ORDER BY fecha DESC");
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['nuevo_departamento'])) {
+    $nuevo = trim($_POST['nuevo_departamento']);
+    if ($nuevo !== '') {
+        $stmt = $conn->prepare("INSERT INTO departamentos (nombre) VALUES (?)");
+        $stmt->bind_param('s', $nuevo);
+        $stmt->execute();
+    }
+}
+
+$departamentos = $conn->query("SELECT id, nombre FROM departamentos ORDER BY nombre");
+$quejas = $conn->query("SELECT q.id, q.nombre, q.correo, d.nombre AS departamento, q.mensaje, q.fecha FROM quejas q JOIN departamentos d ON q.departamento_id = d.id ORDER BY q.fecha DESC");
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -27,6 +37,17 @@ $quejas = $conn->query("SELECT id, nombre, correo, destino, mensaje, fecha FROM 
         </ul>
     </aside>
     <main class="dashboard-content">
+        <h1>Departamentos</h1>
+        <form method="POST" class="vacantes-form" style="max-width:300px;margin-bottom:20px;">
+            <input type="text" name="nuevo_departamento" placeholder="Nombre del departamento" required>
+            <button type="submit">Agregar</button>
+        </form>
+        <ul>
+            <?php while($dep = $departamentos->fetch_assoc()): ?>
+                <li><?php echo htmlspecialchars($dep['nombre']); ?></li>
+            <?php endwhile; ?>
+        </ul>
+
         <h1>Quejas recibidas</h1>
         <table class="vacantes-table">
             <tr>
@@ -40,7 +61,7 @@ $quejas = $conn->query("SELECT id, nombre, correo, destino, mensaje, fecha FROM 
             <tr>
                 <td><?php echo htmlspecialchars($row['nombre']); ?></td>
                 <td><?php echo htmlspecialchars($row['correo']); ?></td>
-                <td><?php echo htmlspecialchars($row['destino']); ?></td>
+                <td><?php echo htmlspecialchars($row['departamento']); ?></td>
                 <td><?php echo nl2br(htmlspecialchars($row['mensaje'])); ?></td>
                 <td><?php echo htmlspecialchars($row['fecha']); ?></td>
             </tr>

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -33,13 +33,19 @@ CREATE TABLE IF NOT EXISTS aplicaciones (
     FOREIGN KEY (vacante_id) REFERENCES vacantes(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS departamentos (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    nombre VARCHAR(100) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE IF NOT EXISTS quejas (
     id INT AUTO_INCREMENT PRIMARY KEY,
     nombre VARCHAR(100) NOT NULL,
     correo VARCHAR(100) NOT NULL,
-    destino VARCHAR(100) NOT NULL,
+    departamento_id INT NOT NULL,
     mensaje TEXT NOT NULL,
-    fecha TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    fecha TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (departamento_id) REFERENCES departamentos(id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO usuarios (usuario, password, rol) VALUES


### PR DESCRIPTION
## Summary
- Añadir tabla `departamentos` y relacionar quejas con departamento
- Mostrar selector de departamento en el formulario de quejas
- Permitir a admin agregar departamentos y ver quejas por departamento

## Testing
- `php -l quejas.php enviar_queja.php quejas_admin.php`
- `mysql --version` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688cdbd906b483238b1d97015e684381